### PR TITLE
Make VM/DV counts optional

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,0 +1,19 @@
+name: Unit Tests
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+run-name: run-unit-tests
+
+jobs:
+  run-unit-tests:
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12' 
+      - name: run validator
+        run: |
+          cd app
+          python3 -m pip install -r requirements.txt
+          python3 -m unittest

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Below details the health check modules available as part of the solution, with s
 | CheckRobinCluster    | Checks RobinCluster Health                                             |                                                                      |
 | CheckRootSyncs       | Checks that RootSyncs are synced and have completed reconciling        |                                                                      |
 | CheckVMRuntime       | Checks that VMruntime is Ready, without any preflight failure          |                                                                      |
-| CheckVirtualMachines | Checks that the expected # of VMs are in a Running State               | **namespace**: namespace to run check against   **count**: expected # of VMs |
-| CheckDataVolumes     | Checks that the expected # of Data Volumes are 100% imported and ready | **namespace**: namespace to run check against   **count**: expected # of DVs |
+| CheckVirtualMachines | Checks that the expected # of VMs are in a Running State               | **namespace**: namespace to run check against <br >   **count**: (Optional) expected # of VMs |
+| CheckDataVolumes     | Checks that the expected # of Data Volumes are 100% imported and ready | **namespace**: namespace to run check against <br >  **count**: (Optional) expected # of DVs |
 
 
 ## Building the image

--- a/app/check_data_volumes.py
+++ b/app/check_data_volumes.py
@@ -8,8 +8,7 @@ log = logging.getLogger("check.datavolumes")
 
 class CheckDataVolumesParameters(BaseModel):
     namespace: str
-    count: int
-
+    count: int | None = None
 
 class CheckDataVolumes:
     def __init__(self, parameters: dict) -> None:
@@ -27,7 +26,7 @@ class CheckDataVolumes:
             namespace=self.namespace,
         )
 
-        if len(resp.get("items")) != self.count:
+        if self.count is not None and len(resp.get("items")) != self.count:
             log.error(
                 f'Found {len(resp.get("items"))} datavolumes but expected {self.count}.'
             )

--- a/app/test_check_data_volumes.py
+++ b/app/test_check_data_volumes.py
@@ -1,0 +1,143 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from check_data_volumes import CheckDataVolumes
+from pydantic import ValidationError
+
+
+class TestCheckDataVolumes(unittest.TestCase):
+    def setUp(self):
+        # Mock the Kubernetes client
+        self.k8s_client_patcher = patch("check_data_volumes.client")
+        self.mock_k8s_client = self.k8s_client_patcher.start()
+        self.mock_custom_objects_api = MagicMock()
+        self.mock_k8s_client.CustomObjectsApi.return_value = (
+            self.mock_custom_objects_api
+        )
+
+    def tearDown(self):
+        self.k8s_client_patcher.stop()
+
+    def test_is_healthy_success(self):
+        """Test is_healthy returns True when all data volumes are succeeded and count matches."""
+        params = {"namespace": "test-ns", "count": 2}
+        checker = CheckDataVolumes(parameters=params)
+
+        mock_dv_list = {
+            "items": [
+                {
+                    "metadata": {"name": "dv1"},
+                    "status": {"phase": "Succeeded", "progress": "100.0%"},
+                },
+                {
+                    "metadata": {"name": "dv2"},
+                    "status": {"phase": "Succeeded", "progress": "100.0%"},
+                },
+            ]
+        }
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_dv_list
+        )
+
+        self.assertTrue(checker.is_healthy())
+        self.mock_custom_objects_api.list_namespaced_custom_object.assert_called_once_with(
+            group="cdi.kubevirt.io",
+            version="v1beta1",
+            plural="datavolumes",
+            namespace="test-ns",
+        )
+
+    def test_is_healthy_incorrect_count(self):
+        """Test is_healthy returns False when the number of data volumes does not match the expected count."""
+        params = {"namespace": "test-ns", "count": 3}
+        checker = CheckDataVolumes(parameters=params)
+
+        mock_dv_list = {
+            "items": [
+                {
+                    "metadata": {"name": "dv1"},
+                    "status": {"phase": "Succeeded", "progress": "100.0%"},
+                },
+                {
+                    "metadata": {"name": "dv2"},
+                    "status": {"phase": "Succeeded", "progress": "100.0%"},
+                },
+            ]
+        }
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_dv_list
+        )
+
+        self.assertFalse(checker.is_healthy())
+
+    def test_is_healthy_phase_not_succeeded(self):
+        """Test is_healthy returns False when a data volume phase is not 'Succeeded'."""
+        params = {"namespace": "test-ns", "count": 2}
+        checker = CheckDataVolumes(parameters=params)
+
+        mock_dv_list = {
+            "items": [
+                {
+                    "metadata": {"name": "dv1"},
+                    "status": {"phase": "Succeeded", "progress": "100.0%"},
+                },
+                {"metadata": {"name": "dv2"}, "status": {"phase": "Pending"}},
+            ]
+        }
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_dv_list
+        )
+
+        self.assertFalse(checker.is_healthy())
+
+    def test_is_healthy_progress_not_complete(self):
+        """Test is_healthy returns False when a data volume progress is not '100.0%'."""
+        params = {"namespace": "test-ns", "count": 2}
+        checker = CheckDataVolumes(parameters=params)
+
+        mock_dv_list = {
+            "items": [
+                {
+                    "metadata": {"name": "dv1"},
+                    "status": {"phase": "Succeeded", "progress": "100.0%"},
+                },
+                {
+                    "metadata": {"name": "dv2"},
+                    "status": {"phase": "Succeeded", "progress": "50.0%"},
+                },
+            ]
+        }
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_dv_list
+        )
+
+        self.assertFalse(checker.is_healthy())
+
+    def test_is_healthy_no_datavolumes_expected(self):
+        """Test is_healthy returns True when no data volumes are found and count is 0."""
+        params = {"namespace": "test-ns", "count": 0}
+        checker = CheckDataVolumes(parameters=params)
+
+        mock_dv_list = {"items": []}
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_dv_list
+        )
+
+        self.assertTrue(checker.is_healthy())
+
+    def test_init_invalid_parameters(self):
+        """Test that initializing with invalid parameters raises a ValidationError."""
+        # Missing 'namespace'
+        with self.assertRaises(ValidationError):
+            CheckDataVolumes(parameters={"count": 1})
+
+        # Invalid type for 'count'
+        with self.assertRaises(ValidationError):
+            CheckDataVolumes(parameters={"namespace": "test-ns", "count": "two"})
+
+    def test_init_optional_parameters(self):
+        """Test initilializing with optional parameters."""
+        # Optional 'count'
+        check = CheckDataVolumes(parameters={"namespace": "test-ns"})
+        self.assertIsNone(check.count)
+ 

--- a/app/test_check_virtual_machines.py
+++ b/app/test_check_virtual_machines.py
@@ -1,0 +1,112 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from check_virtual_machines import CheckVirtualMachines
+from pydantic import ValidationError
+
+
+class TestCheckVirtualMachines(unittest.TestCase):
+    def setUp(self):
+        # Mock the Kubernetes client
+        self.k8s_client_patcher = patch("check_virtual_machines.client")
+        self.mock_k8s_client = self.k8s_client_patcher.start()
+        self.mock_custom_objects_api = MagicMock()
+        self.mock_k8s_client.CustomObjectsApi.return_value = (
+            self.mock_custom_objects_api
+        )
+
+    def tearDown(self):
+        self.k8s_client_patcher.stop()
+
+    def test_is_healthy_success(self):
+        """Test is_healthy returns True when all VMs are running and count matches."""
+        params = {"namespace": "test-ns", "count": 2}
+        checker = CheckVirtualMachines(parameters=params)
+
+        mock_vm_list = {
+            "items": [
+                {
+                    "metadata": {"name": "vm1"},
+                    "status": {"state": "Running"},
+                },
+                {
+                    "metadata": {"name": "vm2"},
+                    "status": {"state": "Running"},
+                },
+            ]
+        }
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_vm_list
+        )
+
+        self.assertTrue(checker.is_healthy())
+        
+
+        self.mock_custom_objects_api.list_namespaced_custom_object.assert_called_once_with(
+            group="vm.cluster.gke.io",
+            version="v1",
+            plural="virtualmachines",
+            namespace="test-ns",
+        )
+
+    def test_is_healthy_incorrect_count(self):
+        """Test is_healthy returns False when the number of VMs does not match the expected count."""
+        params = {"namespace": "test-ns", "count": 3}
+        checker = CheckVirtualMachines(parameters=params)
+
+        mock_vm_list = {
+            "items": [
+                {"metadata": {"name": "vm1"}, "status": {"state": "Running"}},
+                {"metadata": {"name": "vm2"}, "status": {"state": "Running"}},
+            ]
+        }
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_vm_list
+        )
+
+        self.assertFalse(checker.is_healthy())
+
+    def test_is_healthy_vm_not_running(self):
+        """Test is_healthy returns True when a VM is not in the 'Running' state."""
+        params = {"namespace": "test-ns", "count": 2}
+        checker = CheckVirtualMachines(parameters=params)
+
+        mock_vm_list = {
+            "items": [
+                {"metadata": {"name": "vm1"}, "status": {"state": "Running"}},
+                {"metadata": {"name": "vm2"}, "status": {"state": "Stopped"}},
+            ]
+        }
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_vm_list
+        )
+
+        self.assertTrue(checker.is_healthy())
+
+    def test_init_invalid_parameters(self):
+        """Test that initializing with invalid parameters raises a ValidationError."""
+        # Missing 'namespace'
+        with self.assertRaises(ValidationError):
+            CheckVirtualMachines(parameters={"count": "1"})
+
+        # Invalid type for 'count'
+        with self.assertRaises(ValidationError):
+            CheckVirtualMachines(parameters={"namespace": "test-ns", "count": "two"})
+
+    def test_init_optional_parameters(self):
+        """Test initilializing with optional parameters."""
+        # Optional 'count'
+        check = CheckVirtualMachines(parameters={"namespace": "test-ns"})
+        self.assertIsNone(check.count)
+
+    def test_is_healthy_no_vms_expected(self):
+        """Test is_healthy returns True when no VMs are found and count is 0."""
+        params = {"namespace": "test-ns", "count": 0}
+        checker = CheckVirtualMachines(parameters=params)
+
+        mock_vm_list = {"items": []}
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_vm_list
+        )
+
+        self.assertTrue(checker.is_healthy())

--- a/app/test_config.py
+++ b/app/test_config.py
@@ -26,3 +26,10 @@ class TestConfig(unittest.TestCase):
     def test_required_fields(self):
         os.environ["APP_CONFIG_PATH"] = "testdata/missing_required.yaml"
         self.assertRaises(ValidationError, read_config)
+
+    def test_optional_module_parameters(self):
+        os.environ["APP_CONFIG_PATH"] = "testdata/optional_module_parameters.yaml"
+        result = read_config()
+        self.assertEqual(len(result.platform_checks), 4)
+        self.assertEqual(len(result.workload_checks), 2)
+        

--- a/app/testdata/optional_module_parameters.yaml
+++ b/app/testdata/optional_module_parameters.yaml
@@ -1,0 +1,15 @@
+platform_checks:
+- name: Node Health
+  module: CheckNodes
+- name: Robin Cluster Health
+  module: CheckRobinCluster
+- name: Root Sync Check
+  module: CheckRootSyncs
+- name: VMRuntime Check
+  module: CheckVMRuntime
+
+workload_checks:
+- name: VM Workloads Health
+  module: CheckVirtualMachines
+- name: VM Data Volume Health
+  module: CheckDataVolumes


### PR DESCRIPTION
Make VM and DV module counts optional. This allows confirming the health of an arbitrary number of VMs/DVs within a given namespace. 