### PR TITLE
Check virtual machine disks

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -8,6 +8,7 @@ from check_nodes import CheckNodes
 from check_robin_cluster import CheckRobinCluster
 from check_root_syncs import CheckRootSyncs
 from check_virtual_machines import CheckVirtualMachines
+from check_virtual_machine_disks import CheckVirtualMachineDisks
 from check_vmruntime import CheckVMRuntime
 from kubernetes import config
 
@@ -19,6 +20,7 @@ health_check_map = {
     CheckVMRuntime.__name__.lower(): CheckVMRuntime,
     CheckDataVolumes.__name__.lower(): CheckDataVolumes,
     CheckVirtualMachines.__name__.lower(): CheckVirtualMachines,
+    CheckVirtualMachineDisks.__name__.lower(): CheckVirtualMachineDisks,
 }
 
 default_health_checks = [

--- a/app/app.py
+++ b/app/app.py
@@ -11,6 +11,7 @@ from check_nodes import CheckNodes
 from check_robin_cluster import CheckRobinCluster
 from check_root_syncs import CheckRootSyncs
 from check_virtual_machines import CheckVirtualMachines
+from check_virtual_machine_disks import CheckVirtualMachineDisks
 from check_vmruntime import CheckVMRuntime
 from config import read_config
 from flask import Flask, abort
@@ -38,6 +39,7 @@ health_check_map = {
     CheckVMRuntime.__name__: CheckVMRuntime,
     CheckDataVolumes.__name__: CheckDataVolumes,
     CheckVirtualMachines.__name__: CheckVirtualMachines,
+    CheckVirtualMachineDisks.__name__: CheckVirtualMachineDisks
 }
 
 

--- a/app/check_root_syncs.py
+++ b/app/check_root_syncs.py
@@ -8,6 +8,24 @@ log = logging.getLogger("check.rootsyncs")
 
 class CheckRootSyncs:
     def is_healthy(self):
+        k8s_app = client.AppsV1Api()
+        try:
+            resp = k8s_app.read_namespaced_deployment(
+                name="config-management-operator",
+                namespace="config-management-system",
+            )
+            if resp.status.ready_replicas != 1:
+                log.error(
+                    "deployment.apps/config-management-operator is not running."
+                    + f" Found {resp.status.ready_replicas} ready replicas but expected 1"
+                )
+                return False
+        except client.ApiException as e:
+            log.error(
+                "Exception when calling AppsV1Api->read_namespaced_deployment: %s\n" % e
+            )
+            return False
+
         k8s = client.CustomObjectsApi()
         resp = k8s.list_namespaced_custom_object(
             group="configsync.gke.io",

--- a/app/check_root_syncs.py
+++ b/app/check_root_syncs.py
@@ -8,23 +8,23 @@ log = logging.getLogger("check.rootsyncs")
 
 class CheckRootSyncs:
     def is_healthy(self):
-        k8s_app = client.AppsV1Api()
-        try:
-            resp = k8s_app.read_namespaced_deployment(
-                name="config-management-operator",
-                namespace="config-management-system",
-            )
-            if resp.status.ready_replicas != 1:
-                log.error(
-                    "deployment.apps/config-management-operator is not running."
-                    + f" Found {resp.status.ready_replicas} ready replicas but expected 1"
-                )
-                return False
-        except client.ApiException as e:
-            log.error(
-                "Exception when calling AppsV1Api->read_namespaced_deployment: %s\n" % e
-            )
-            return False
+        # k8s_app = client.AppsV1Api()
+        # try:
+        #     resp = k8s_app.read_namespaced_deployment(
+        #         name="config-management-operator",
+        #         namespace="config-management-system",
+        #     )
+        #     if resp.status.ready_replicas != 1:
+        #         log.error(
+        #             "deployment.apps/config-management-operator is not running."
+        #             + f" Found {resp.status.ready_replicas} ready replicas but expected 1"
+        #         )
+        #         return False
+        # except client.ApiException as e:
+        #     log.error(
+        #         "Exception when calling AppsV1Api->read_namespaced_deployment: %s\n" % e
+        #     )
+        #     return False
 
         k8s = client.CustomObjectsApi()
         resp = k8s.list_namespaced_custom_object(

--- a/app/check_virtual_machine_disks.py
+++ b/app/check_virtual_machine_disks.py
@@ -1,0 +1,52 @@
+import logging
+
+from kubernetes import client
+from pydantic import BaseModel
+
+log = logging.getLogger("check.virtualmachinedisks")
+
+
+class CheckVirtualMachineDisksParameters(BaseModel):
+    namespace: str
+    count: int | None = None
+
+
+class CheckVirtualMachineDisks:
+    def __init__(self, parameters: dict) -> None:
+        params = CheckVirtualMachineDisksParameters(**parameters)
+        self.namespace = params.namespace
+        self.count = params.count
+
+    def is_healthy(self):
+        k8s = client.CustomObjectsApi()
+        resp = k8s.list_namespaced_custom_object(
+            group="vm.cluster.gke.io",
+            version="v1",
+            plural="virtualmachinedisks",
+            namespace=self.namespace,
+        )
+        
+        # Check for specified count of virtualmachinedisks
+        if self.count is not None and len(resp.get("items")) != self.count:
+            log.error(
+                f'Found {len(resp.get("items"))} virtualmachinedisks but expected {self.count}.'
+            )
+            return False
+       
+        # Assert that each virtualmachine disk is Succeeded.
+        for virtual_machine_disk in resp.get("items"):
+            if virtual_machine_disk.get("status").get("phase") != "Succeeded":
+                log.error(
+                    f'DataVolume {virtual_machine_disk.get("metadata").get("name")} phase not succeeded'
+                )
+                return False
+            
+            if virtual_machine_disk.get("status").get("progress") != "100.0%" and not virtual_machine_disk.get("metadata").get("labels").get("vm.cluster.gke.io/virtual-machine-restore"):
+                log.error(
+                    f'DataVolume {virtual_machine_disk.get("metadata").get("name")} not finished importing'
+                )
+                return False
+            
+
+        log.info("Check virtual machines disks passed")
+        return True

--- a/app/test_check_virtual_machine_disks.py
+++ b/app/test_check_virtual_machine_disks.py
@@ -1,0 +1,175 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from check_virtual_machine_disks import CheckVirtualMachineDisks
+from pydantic import ValidationError
+
+
+class TestCheckVirtualMachineDisks(unittest.TestCase):
+    def setUp(self):
+        # Mock the Kubernetes client
+        self.k8s_client_patcher = patch("check_virtual_machine_disks.client")
+        self.mock_k8s_client = self.k8s_client_patcher.start()
+        self.mock_custom_objects_api = MagicMock()
+        self.mock_k8s_client.CustomObjectsApi.return_value = (
+            self.mock_custom_objects_api
+        )
+
+    def tearDown(self):
+        self.k8s_client_patcher.stop()
+
+    def test_is_healthy_success(self):
+        """Test is_healthy returns True when all disks are Succeeded and count matches."""
+        params = {"namespace": "test-ns", "count": 2}
+        checker = CheckVirtualMachineDisks(parameters=params)
+
+        mock_disk_list = {
+            "items": [
+                {
+                    "metadata": {"name": "disk1", "labels": {}},
+                    "status": {"phase": "Succeeded", "progress": "100.0%"},
+                },
+                {
+                    "metadata": {"name": "disk2", "labels": {}},
+                    "status": {"phase": "Succeeded", "progress": "100.0%"},
+                },
+            ]
+        }
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_disk_list
+        )
+
+        self.assertTrue(checker.is_healthy())
+        self.mock_custom_objects_api.list_namespaced_custom_object.assert_called_once_with(
+            group="vm.cluster.gke.io",
+            version="v1",
+            plural="virtualmachinedisks",
+            namespace="test-ns",
+        )
+
+    def test_is_healthy_restored_disk_label(self):
+        """Test is_healthy returns True for a restored disk even if not fully imported."""
+        params = {"namespace": "test-ns", "count": 2}
+        checker = CheckVirtualMachineDisks(parameters=params)
+
+        mock_disk_list = {
+            "items": [
+                {
+                    "metadata": {"name": "disk1", "labels": {}},
+                    "status": {"phase": "Succeeded", "progress": "100.0%"},
+                },
+                {
+                    "metadata": {
+                        "name": "disk2",
+                        "labels": {"vm.cluster.gke.io/virtual-machine-restore": "true"},
+                    },
+                    "status": {"phase": "Succeeded"},
+                },
+            ]
+        }
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_disk_list
+        )
+
+        self.assertTrue(checker.is_healthy())
+        
+    def test_is_not_suceeded(self):
+        """Test is_healthy returns False when the number of disks does not match the expected count."""
+        params = {"namespace": "test-ns", "count": 1}
+        checker = CheckVirtualMachineDisks(parameters=params)
+
+        mock_disk_list = {
+            "items": [
+                {
+                    "metadata": {"name": "disk1_inprogress", "labels": {}},
+                    "status": {"phase": "Inprogress", "progress": "100.0%"},
+                }
+            ]
+        }
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_disk_list
+        )
+
+        self.assertFalse(checker.is_healthy())
+        
+    def test_is_healthy_incorrect_count(self):
+        """Test is_healthy returns False when the number of disks does not match the expected count."""
+        params = {"namespace": "test-ns", "count": 3}
+        checker = CheckVirtualMachineDisks(parameters=params)
+
+        mock_disk_list = {
+            "items": [
+                {
+                    "metadata": {"name": "disk1", "labels": {}},
+                    "status": {"phase": "Succeeded", "progress": "100.0%"},
+                },
+                {
+                    "metadata": {"name": "disk2", "labels": {}},
+                    "status": {"phase": "Succeeded", "progress": "100.0%"},
+                },
+            ]
+        }
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_disk_list
+        )
+
+        self.assertFalse(checker.is_healthy())
+
+
+    def test_is_healthy_disk_not_imported(self):
+        """Test is_healthy returns False when a disk has not been fully imported."""
+        params = {"namespace": "test-ns", "count": 2}
+        checker = CheckVirtualMachineDisks(parameters=params)
+
+        mock_disk_list = {
+            "items": [
+                {
+                    "metadata": {"name": "disk1", "labels": {}},
+                    "status": {"phase": "Succeeded", "progress": "100.0%"},
+                },
+                {
+                    "metadata": {"name": "disk2_50percent", "labels": {}},
+                    "status": {"phase": "Succeeded", "progress": "50.0%"},
+                },
+            ]
+        }
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_disk_list
+        )
+
+        self.assertFalse(checker.is_healthy())
+
+
+    def test_init_invalid_parameters(self):
+        """Test that initializing with invalid parameters raises a ValidationError."""
+        # Missing 'namespace'
+        with self.assertRaises(ValidationError):
+            CheckVirtualMachineDisks(parameters={"count": "1"})
+
+        # Invalid type for 'count'
+        with self.assertRaises(ValidationError):
+            CheckVirtualMachineDisks(
+                parameters={"namespace": "test-ns", "count": "two"}
+            )
+
+    def test_init_optional_parameters(self):
+        """Test initilializing with optional parameters."""
+        # Optional 'count'
+        check = CheckVirtualMachineDisks(parameters={"namespace": "test-ns"})
+        self.assertIsNone(check.count)
+
+    def test_is_healthy_no_disks_expected(self):
+        """Test is_healthy returns True when no disks are found and count is 0."""
+        params = {"namespace": "test-ns", "count": 0}
+        checker = CheckVirtualMachineDisks(parameters=params)
+
+        mock_disk_list = {"items": []}
+        self.mock_custom_objects_api.list_namespaced_custom_object.return_value = (
+            mock_disk_list
+        )
+
+        self.assertTrue(checker.is_healthy())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 datavolume will be an inconsistent health check as soon as any volumesnapshot restores take place on a cluster. Instead use virtualmachinedisks to understand if the gdisk is suceeeded, either by 100%  or a restored volumesnapshot that is checked by label.