### PR TITLE
Adjust group based RBAC query for 1.10+ clusters and catch all health check exceptions

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -128,16 +128,18 @@ def run_checks():
                             checks_failed.append(name)
                         else:
                             logging.info(f"Check '{name}' failed but is set to be ignored.")
-                # Handling k8s resource not found here as it is not
-                # handled in the individual checks.
-                except ApiException as e:
-                    if e.status == 404:
+                except Exception as e:  # pylint: disable=broad-except
+                    if isinstance(e, ApiException) and e.status == 404:
                         if on_failure == "fail":
                             checks_failed.append(name)
                         else:
-                            logging.info(f"Check '{name}' failed with 404 but is set to be ignored.")
+                            logging.info(
+                                f"Check '{name}' failed with 404 but is set to be ignored."
+                            )
                     else:
-                        raise
+                        logging.error(f"Check '{name}' failed with exception: {e}", exc_info=True)
+                        if on_failure == "fail":
+                            checks_failed.append(name)
             return checks_failed
 
         platform_checks_failed = wait_on_futures(platform_checks_futures)

--- a/app/check_google_group_rbac.py
+++ b/app/check_google_group_rbac.py
@@ -17,21 +17,28 @@ GOOGLE_GROUP_RBAC_FAILURE_TOTAL = Counter(
 
 class CheckGoogleGroupRBAC:
     def is_healthy(self):
-        k8s = client.CustomObjectsApi()
-        resp = k8s.list_namespaced_custom_object(
-            group="authentication.gke.io",
-            version="v2alpha1",
-            plural="clientconfigs",
-            namespace="kube-public",
-        )
+        try:
+            k8s = client.CustomObjectsApi()
+            resp = k8s.list_cluster_custom_object(
+                group="authentication.gke.io",
+                version="v2alpha1",
+                plural="clientconfigs",
+            )
+        except Exception as err:
+            log.error("An error occurred fetching the clientconfig %s", err)
+            GOOGLE_GROUP_RBAC_FAILURE_TOTAL.inc()
+            return False
 
         try:
             clientconfig = resp.get("items")[0]
 
-            if clientconfig.get("metadata").get("name") != "default":
-                log.error(
-                    "Did not find expected default.kube-public clientconfig object"
-                )
+            if clientconfig.get("metadata").get("name") != "default" and clientconfig.get("namespace") != "kube-public":
+                log.error("Did not find expected default.kube-public clientconfig object")
+                GOOGLE_GROUP_RBAC_FAILURE_TOTAL.inc()
+                return False
+
+            if clientconfig.get("spec").get("authentication") is None:
+                log.error("No authentication methods found in default.kube-public clientconfig object")
                 GOOGLE_GROUP_RBAC_FAILURE_TOTAL.inc()
                 return False
 


### PR DESCRIPTION
On GDC 1.10+ clusters, direct access to the default.kube-public clientconfig is blocked. This bypasses the blocking policy by querying for all clientconfigs to verify group based rbac configuration. 